### PR TITLE
fix: show suggestions on unedited source change

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,13 @@
 
 {
-	"eslint.autoFixOnSave": true,
 	"eslint.packageManager": "yarn",
-	"eslint.validate": [
-		{ "language": "javascript", "autoFix": true },
-		{ "language": "html", "autoFix": true }
-	],
+	"eslint.validate": [ "javascript" ],
 	"files.watcherExclude": {
 		"**/.git/objects/**": true,
 		"**/.git/subtree-cache/**": true,
 		"**/node_modules/**": true
+	},
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": true
 	}
 }

--- a/paper-autocomplete.js
+++ b/paper-autocomplete.js
@@ -471,9 +471,9 @@ Polymer({
 	],
 
 	_sourceChanged(newSource) {
-		const text = this.text;
+		const text = this.text || '';
 		// eslint-disable-next-line eqeqeq
-		if (!Array.isArray(newSource) || newSource.length === 0 || text == null || text.length < this.minLength) {
+		if (!Array.isArray(newSource) || newSource.length === 0 || text.length < this.minLength) {
 			return;
 		}
 		if (!this.$.autocompleteInput.focused) {


### PR DESCRIPTION
When source changes after focus, but the user hasn't started
writing anything in the input yet, `this.text` is `null` instead
of `''`.
This causes the suggestions to not be shown, even if `minLength`
is 0.
This adjusts the conditions a bit to allow those suggestions.

Also updates vscode settings.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>