### PR TITLE
fix: restricted validation

### DIFF
--- a/paper-autocomplete.js
+++ b/paper-autocomplete.js
@@ -619,9 +619,6 @@ Polymer({
    */
 	setOption(option) {
 		if (option == null) {
-			this.text = '';
-			this.value = '';
-			this._hideClearButton();
 			return;
 		}
 		this.text = option[this.textProperty] || option.text;

--- a/paper-autocomplete.js
+++ b/paper-autocomplete.js
@@ -618,6 +618,12 @@ Polymer({
    * @param {Object} option
    */
 	setOption(option) {
+		if (option == null) {
+			this.text = '';
+			this.value = '';
+			this._hideClearButton();
+			return;
+		}
 		this.text = option[this.textProperty] || option.text;
 		this.value = this._value = option[this.valueProperty] || option.value;
 		this._showClearButton();

--- a/paper-autocomplete.js
+++ b/paper-autocomplete.js
@@ -462,7 +462,10 @@ Polymer({
      */
 		selectedOption: {
 			type: Object,
-			notify: true
+			notify: true,
+			observer: function () { // eslint-disable-line object-shorthand
+				this.setOption(this.selectedOption);
+			}
 		}
 	},
 
@@ -555,7 +558,6 @@ Polymer({
    */
 	_onAutocompleteSelected(event) {
 		const selection = event.detail;
-
 		this.value = this._value = selection.value;
 		this.text = selection.text;
 	},
@@ -617,7 +619,7 @@ Polymer({
    */
 	setOption(option) {
 		this.text = option[this.textProperty] || option.text;
-		this.value = option[this.valueProperty] || option.value;
+		this.value = this._value = option[this.valueProperty] || option.value;
 		this._showClearButton();
 	},
 


### PR DESCRIPTION
The component refuses to pass validation when the restricted property is set together with options and a selected option and this pull request is an attempt to fix it.

In the component there is a `_value` property. If restricted is true, then this property is checked so it is not empty, if so then it fails validation. The property is filled when `_onAutocompleteSelected` is triggered, this does not seem to be made when an option is set by the `selectedOption` property. This pull request is an attempt to fix it by using the `setOption` which previously does not seem to be in use.

Redmine #24924 with test instructions.
