### PR TITLE
fix: hide suggestions on clear

### DIFF
--- a/paper-autocomplete.js
+++ b/paper-autocomplete.js
@@ -515,12 +515,6 @@ Polymer({
 		if (!this.$.autocompleteInput.focused) {
 			this.$.autocompleteInput.focus();
 		}
-
-		this.$.paperAutocompleteSuggestions._handleSuggestions({
-			target: {
-				value: ''
-			}
-		});
 	},
 
 	/**


### PR DESCRIPTION
Run the clear() function, check that the suggestions list does not open.

Redmine #24243 - also check this for an explanation and possible alternatives.